### PR TITLE
Fix some errors and warnings with newer gcc compilers

### DIFF
--- a/ann_wrapper/@ann/ann.m
+++ b/ann_wrapper/@ann/ann.m
@@ -6,7 +6,7 @@ function anno = ann(data)
 %   anno = ann(pts)
 %
 % Input:
-%   pts - (d)x(N) matrix of d-dimensional veecotrs representing N points
+%   pts - (d)x(N) matrix of d-dimensional vectors representing N points
 %
 % Output:
 %   anno - object handle to be used in class' methods

--- a/ann_wrapper/@ann/private/ANN.cpp
+++ b/ann_wrapper/@ann/private/ANN.cpp
@@ -163,7 +163,7 @@ ANNbool ANNorthRect::inside(int dim, ANNpoint p)
 //	Error handler
 //----------------------------------------------------------------------
 
-void annError(char *msg, ANNerr level)
+void annError(const char *msg, ANNerr level)
 {
 	if (level == ANNabort) {
 		cerr << "ANN: ERROR------->" << msg << "<-------------ERROR\n";

--- a/ann_wrapper/@ann/private/ANN.h
+++ b/ann_wrapper/@ann/private/ANN.h
@@ -87,6 +87,8 @@
 //  basic includes
 //----------------------------------------------------------------------
 
+#include <cstdlib>
+#include <cstring>
 #include <cmath>			// math includes
 #include <iostream>			// I/O streams
 

--- a/ann_wrapper/@ann/private/ANNx.h
+++ b/ann_wrapper/@ann/private/ANNx.h
@@ -61,7 +61,7 @@ extern int		ANNptsVisited;		// number of pts visited in search
 //----------------------------------------------------------------------
 
 void annError(					// ANN error routine
-	char			*msg,		// error message
+	const char		*msg,		// error message
 	ANNerr			level);		// level of error
 
 void annPrintPt(				// print a point

--- a/ann_wrapper/@ann/private/perf.cpp
+++ b/ann_wrapper/@ann/private/perf.cpp
@@ -102,7 +102,7 @@ DLL_API void annUpdateStats()				// update stats with current counts
 }
 
 										// print a single statistic
-void print_one_stat(char *title, ANNsampStat s, double div)
+void print_one_stat(const char *title, ANNsampStat s, double div)
 {
 	cout << title << "= [ ";
 	cout.width(9); cout << s.mean()/div			<< " : ";


### PR DESCRIPTION
Hi and thank you for providing this very helpful collection of Matlab wrappers. I'm using the ANN part and I'm quite satisfied with it.

When I tried setting it up, I ran into a few problems that I believe are related to me using a newer version of gcc (4.7.2).

There were errors complaining about undefined functions "exit()" and "strcmp()", which I got rid of by including `<cstdlib>` and `<cstring>`.

Another problem was the usage of `char` instead of `const char` in some places, which is deprecated. Replacing it didn't change the semantics of the code, so I did that too. 

Now the code compiles fine without errors or warnings in Linux using gcc 4.7.2 and Matlab R2012a. Perhaps you want to see if these changes affect the workings of the code on your system and merge them if everything is fine.
